### PR TITLE
validate5 1.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
+
+
 [1]: https://github.com/IonicaBizau/validate5/issues
 
 [2]: https://github.com/IonicaBizau/code-style

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,63 @@
+## Documentation
+
+You can see below the API reference of this module.
+
+### `validate5(forms)`
+Handles the submit event on the selected forms.
+
+You may want to extend the `validate5.patterns` object with custom types. By default it has validation for:
+
+ - `email`: `[emailRegex, "Invalid email address"]`
+
+e.g. `validate5.patterns.myCustomType = [/^[0-9]+$/g, "Not a number."]`
+
+Use the `validate5.skips` array to handle elements that should be skipped when validating. By default it skips the `type=submit` inputs.
+
+e.g.
+
+```js
+validate5.skips.push(function (c) {
+  if (c.getattribute("data-ignore-validation")) { return true; }
+});
+```
+
+#### Params
+- **String** `forms`: The form(s) selector you want to automagically validate on submit.
+
+### `validateInput(input)`
+Validates an input element.
+
+#### Params
+- **HTMLElement** `input`: The input to validate.
+
+#### Return
+- **Validify** The [`validify`](https://github.com/IonicaBizau/validify) result.
+
+### `inputs(formElm, cb)`
+Iterate the inputs in the provided form.
+
+#### Params
+- **HTMLElement** `formElm`: The form element.
+- **Function** `cb`: The callback function.
+
+#### Return
+- **Array** The array of inputs.
+
+### `validateForm(formElm)`
+Validates the form element.
+
+#### Params
+- **HTMLElement** `formElm`: The form element.
+
+#### Return
+- **Array** An array of errors.
+
+### `showErrors(formElm)`
+Validates the form and displays the errors.
+
+#### Params
+- **HTMLElement** `formElm`: The `<form>` element to validate.
+
+#### Return
+- **Array|Boolean** An array of errors or `false` if all the fields are valid.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # validate5 [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/validate5.svg)](https://www.npmjs.com/package/validate5) [![Downloads](https://img.shields.io/npm/dt/validate5.svg)](https://www.npmjs.com/package/validate5) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Form validations made easy.
@@ -5,7 +6,7 @@
 [![validate5](http://i.imgur.com/tLbLEeJ.png)](http://ionicabizau.github.io/validate5/example)
 
 ## :cloud: Installation
-    
+
 
 Check out the [`dist`](/dist) directory to download the needed files and include them on your page.
 
@@ -15,10 +16,10 @@ If you're using this module in a CommonJS environment, you can install it from `
 $ npm i --save validate5
 ```
 
-        
+
 ## :clipboard: Example
 
-        
+
 
 ```js
 /**
@@ -43,9 +44,10 @@ $ npm i --save validate5
 // To validate the forms on submit, use:
 validate5("form");
 ```
-    
+
 ## :memo: Documentation
-        
+
+
 ### `validate5(forms)`
 Handles the submit event on the selected forms.
 
@@ -105,14 +107,16 @@ Validates the form and displays the errors.
 #### Return
 - **Array|Boolean** An array of errors or `false` if all the fields are valid.
 
-        
+
+
 ## :yum: How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
 
+
 ## :scroll: License
-    
+
 [MIT][license] © [Ionică Bizău][website]
-    
+
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW
 [donate-now]: http://i.imgur.com/6cMbHOC.png
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "validate5",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Form validations made easy.",
   "main": "lib/index.js",
   "scripts": {
@@ -25,7 +25,18 @@
   },
   "homepage": "https://github.com/IonicaBizau/validate5#readme",
   "blah": {
-      "ex_img": "http://i.imgur.com/tLbLEeJ.png",
-      "ex_url": "http://ionicabizau.github.io/validate5/example"
-  }
+    "ex_img": "http://i.imgur.com/tLbLEeJ.png",
+    "ex_url": "http://ionicabizau.github.io/validate5/example"
+  },
+  "files": [
+    "bin/",
+    "app/",
+    "lib/",
+    "dist/",
+    "src/",
+    "resources/",
+    "menu/",
+    "cli.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
